### PR TITLE
Notification improvements

### DIFF
--- a/cohost/models/user.py
+++ b/cohost/models/user.py
@@ -137,7 +137,20 @@ class User:
     @property
     def notifications(self):
         return self.notificationsPagified(notificationsPerPage = 10)
-
+    
+    @property
+    def allNotifications(self):
+        page = 0
+        notifsPerPage = 100
+        notifs = self.notificationsPagified(page = page, notificationsPerPage = notifsPerPage)
+        newNotifs = notifs
+        while len(newNotifs) == notifsPerPage:
+            page += 1
+            newNotifs = self.notificationsPagified(page = page, notificationsPerPage = notifsPerPage)
+            for n in newNotifs:
+                notifs.append(n)
+        return notifs
+    
     def notificationsPagified(self, page = 0, notificationsPerPage = 10):
         nJson = fetch('GET', 'notifications/list', {
             'offset': page * notificationsPerPage,

--- a/cohost/models/user.py
+++ b/cohost/models/user.py
@@ -136,9 +136,12 @@ class User:
 
     @property
     def notifications(self):
+        return self.notificationsPagified(notificationsPerPage = 10)
+
+    def notificationsPagified(self, page = 0, notificationsPerPage = 10):
         nJson = fetch('GET', 'notifications/list', {
-            'offset': 0,
-            'limit': 5000
+            'offset': page * notificationsPerPage,
+            'limit': notificationsPerPage
         }, generate_login_cookies(self.cookie))
         return buildFromNotifList(nJson, self)
 

--- a/demos/printNotifs.py
+++ b/demos/printNotifs.py
@@ -1,0 +1,30 @@
+import os
+from cohost.models.user import User
+
+def main():
+    print('logging in... ')
+    username = os.environ.get('cohostUser')
+    password = os.environ.get('cohostPass')
+    handle = os.environ.get('cohostHandle')
+    if username is None:
+        username = input('username: ')
+    if password is None:
+        password = input('password: ')
+    if handle is None:
+        handle = input('handle: ')
+    user = User.login(username, password)
+    
+    print('done!', end='\n\n')
+    # get last 10 notifications
+    print('last 10 notifs: {}'.format(len(user.notifications)), end='\n\n')
+
+    # example of custom pagination
+    user.notificationsPagified(page = 2, notificationsPerPage=5)
+
+    # Example of all notifications!
+    print('retrieving all notifs... ')
+    notifs = user.allNotifications
+    print('you have recieved {} total lifetime notifs.'.format(len(notifs)))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
fixed:
 - prevent stall when loading a notification in association with a deleted post
 - stop hitting cohost API as heavily by requesting 5000 notifications at once for All notification requests

new!
 - pagified notifications with `User.notificationsPagified(self, page = 0, notificationsPerPage = 50)`
 - abiltiy to still get All Notifications if you *really* want to, but, now works if you have more than 5k! - see `User.allNotifications`
