### PR TITLE
Use standard library's pbkdf2_hmac implementation instead of backports.pbkdf2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 requests = "*"
-"backports.pbkdf2" = "*"
 
 [dev-packages]
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5bbeb2d7dc71a75019eddeff9169245746943380dd74fc0a6c43c711d8f91938"
+            "sha256": "cac45fdc7d0842968c158ce32bbb7a636dfff4dc144688abdb0bb4df30084b8a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,6 @@
         ]
     },
     "default": {
-        "backports.pbkdf2": {
-            "hashes": [
-                "sha256:6d342adb73dd86396b7c604f6da473bf98eb5356e68b99c913a30a5e64832e03"
-            ],
-            "index": "pypi",
-            "version": "==0.1"
-        },
         "certifi": {
             "hashes": [
                 "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",

--- a/cohost/models/user.py
+++ b/cohost/models/user.py
@@ -3,9 +3,8 @@ from re import U
 from cohost.models.project import EditableProject
 from cohost.network import fetch, fetchTrpc, generate_login_cookies
 from cohost.models.notification import buildFromNotifList
-import hashlib
+from hashlib import pbkdf2_hmac
 import base64
-from backports.pbkdf2 import pbkdf2_hmac
 
 
 class User:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     python_requires=">=3.7.*",
-    install_requires=['requests','backports.pbkdf2'],
+    install_requires=['requests'],
     license=about['__license__'],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
### Changes
Python's standard module library has implemented [`pbkdf2_hmac` as part of the `hashlib` module](https://docs.python.org/3/library/hashlib.html?highlight=hashlib#hashlib.pbkdf2_hmac) since Python 3.4. Instead of using the `backports.pbkdf2` module ([which is intended for use with Python 2.6-3.3](https://pypi.org/project/backports.pbkdf2/)), let's use the built-in version. The standard library function implements the same functionality as the backport module (or, rather, the other way around), making this a 1:1 replacement for our use case.

The only compatibility issue (assuming we want Python 3.7+ support) I can see with this change is that `hashlib.pbkdf2_hmac` is deprecated in instances where Python is compiled without OpenSSL support. I don't know of any common Python distributions that do that.

Fixes #13

### Testing
I was able to log in successfully [and chost](https://cohost.org/oliviac-automation-test/post/232422-love-to-title-things) with these changes from a Fedora 37 container running Python 3.11.