### PR TITLE
Remove unused imports and sort used imports

### DIFF
--- a/cohost/models/block.py
+++ b/cohost/models/block.py
@@ -1,8 +1,6 @@
-
-from fileinput import filename
 import requests
+
 from cohost.network import fetch, generate_login_cookies
-import os
 
 
 class Block:

--- a/cohost/models/notification.py
+++ b/cohost/models/notification.py
@@ -51,9 +51,9 @@ class Follow(BaseNotification):
 
 
 def buildFromNotifList(notificationsApiResp: dict, user):
-    from cohost.models.user import User
-    from cohost.models.post import Post
     from cohost.models.comment import Comment as CommentModel
+    from cohost.models.post import Post
+    from cohost.models.user import User
     u = user  # type: User
     user = u  # this whole shitshow is to get intellisense working without circular imports
     # I Love Python

--- a/cohost/models/project.py
+++ b/cohost/models/project.py
@@ -1,6 +1,7 @@
-from cohost.network import fetchTrpc, fetch, generate_login_cookies
+from cohost.models.block import AttachmentBlock
 from cohost.models.post import Post
-from cohost.models.block import Block, AttachmentBlock
+from cohost.network import fetch, generate_login_cookies
+
 # from cohost.models.user import User
 
 

--- a/cohost/models/user.py
+++ b/cohost/models/user.py
@@ -1,10 +1,9 @@
-from distutils.command.build import build
-from re import U
+import base64
+from hashlib import pbkdf2_hmac
+
+from cohost.models.notification import buildFromNotifList
 from cohost.models.project import EditableProject
 from cohost.network import fetch, fetchTrpc, generate_login_cookies
-from cohost.models.notification import buildFromNotifList
-from hashlib import pbkdf2_hmac
-import base64
 
 
 class User:
@@ -126,7 +125,7 @@ class User:
         return None
 
     def resolveSecondaryProject(self, projectData):
-        from cohost.models.project import Project, EditableProject
+        from cohost.models.project import EditableProject, Project
         editableProjects = self.editedProjects
         for project in editableProjects:
             if project.projectId == projectData['projectId']:

--- a/cohost/network.py
+++ b/cohost/network.py
@@ -1,7 +1,7 @@
-from distutils.log import debug
-import requests
 import logging
 import time
+
+import requests
 
 l = logging.getLogger(__name__)
 l.setLevel(logging.DEBUG)

--- a/example.py
+++ b/example.py
@@ -1,9 +1,9 @@
-from cohost.models.user import User
-from cohost.models.post import Post
-from cohost.models.block import AttachmentBlock, MarkdownBlock
-from cohost.models.project import Project, EditableProject
 import os
-import json
+
+from cohost.models.block import AttachmentBlock, MarkdownBlock
+from cohost.models.user import User
+
+
 def main():
     cookie = os.environ.get('COHOST_COOKIE')
     if cookie is None:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 # get key package details from py_pkg/__version__.py
 about = {}  # type: ignore


### PR DESCRIPTION
### Changes
This project has a smattering of unsorted and unused imports. Let's use [`isort`](https://pypi.org/project/isort/) to clean those up. Notably, this removes all remaining imports of `distutils`, which is [slated for removal](https://docs.python.org/3/library/distutils.html) in Python 3.12.

I figure this is a nice incremental change to remove some of the red squiggly underlines for people using the default configuration of the Pylance extension for VS Code (at least, I think that's where these errors stem from). Feel free to let me know you consider these kinds of contributions to be yak shaving- I know some devs don't really care for these PRs, and I'd hate to bother. I'd also be happy to contribute some basic linting PR checks, to keep things like imports clean.

### Testing
Importing this module still works. Was able to successfully [chost](https://cohost.org/oliviac-automation-test/post/233543-0).