### PR TITLE
Project switching

### DIFF
--- a/cohost/models/project.py
+++ b/cohost/models/project.py
@@ -1,6 +1,6 @@
 from cohost.models.block import AttachmentBlock
 from cohost.models.post import Post
-from cohost.network import fetch, generate_login_cookies
+from cohost.network import fetch, generate_login_cookies, fetchTrpc
 
 # from cohost.models.user import User
 
@@ -260,7 +260,14 @@ class EditableProject(Project):
         if not draft:
             return self.getPosts()[0]  # this will be what we just posted
         return None # TODO: Get drafts working!
-        
+    
+    """Set this project as the default project, for actions such as retrieving notifications
+    """
+    def switch(self):
+        fetchTrpc('projects.switchProject', self.user.cookie, {
+            "projectId":self.projectId
+        }, methodType="postjson")
+    
     @staticmethod
     def create(user, projectName, private: bool = False, adult: bool = False) -> Project:
         raise NotImplemented(

--- a/cohost/models/user.py
+++ b/cohost/models/user.py
@@ -150,12 +150,14 @@ class User:
         return notifs
     
     def notificationsPagified(self, page = 0, notificationsPerPage = 10):
-        nJson = fetch('GET', 'notifications/list', {
+        nJson = self.notificationsRaw(page, notificationsPerPage)
+        return buildFromNotifList(nJson, self)
+    
+    def notificationsRaw(self, page = 0, notificationsPerPage = 10):
+        return fetch('GET', 'notifications/list', {
             'offset': page * notificationsPerPage,
             'limit': notificationsPerPage
         }, generate_login_cookies(self.cookie))
-        return buildFromNotifList(nJson, self)
-
 
 """
 

--- a/cohost/network.py
+++ b/cohost/network.py
@@ -64,7 +64,7 @@ def fetch(method: str, endpoint, data: dict, cookies="", complex=False):
     return res
 
 
-def fetchTrpc(methods: list, cookie: str):
+def fetchTrpc(methods: list, cookie: str, data: dict = None, methodType = "get"):
     global cache
     """Fetch data from trpc API
 
@@ -79,11 +79,11 @@ def fetchTrpc(methods: list, cookie: str):
         m = methods
     else:
         m = ','.join(methods)
-    data = get_cache_data(cookie, m)
-    if data is not None:
+    cacheData = get_cache_data(cookie, m)
+    if cacheData is not None:
         l.debug('Cache hit!')
-        return data
-    data = fetch("get", "/trpc/{}".format(m), None,
+        return cacheData
+    data = fetch(methodType, "/trpc/{}".format(m), data=data,
                  cookies=generate_login_cookies(cookie))
     set_cache_data(cookie, m, data)
     return data


### PR DESCRIPTION
Partial fix for #21 - this allows you to switch projects, but, the more ideal option would be to have a temporary override, or to move notifications inside the project! However, this should unblock this usecase