### PR TITLE
Fix reversed transparentShare logic

### DIFF
--- a/cohost/models/notification.py
+++ b/cohost/models/notification.py
@@ -32,12 +32,12 @@ class Share(BaseNotification):
 
     def __str__(self) -> str:
         if self.transparentShare:
-            return "{} shared {} with extra | {}".format(
+            return "{} shared {} | {}".format(
                 self.fromProject.handle,
                 self.toPost.postId,
                 self.timestamp
             )
-        return "{} shared {} | {}".format(
+        return "{} shared {} with extra | {}".format(
             self.fromProject.handle,
             self.toPost.postId,
             self.timestamp


### PR DESCRIPTION
Flips the check in `Share.__str__()` to correctly report whether a share added extra text or not - currently it's backwards.