### PR TITLE
Explicitly add `py.typed` during build process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ repository = "https://github.com/valknight/cohost.py"
 
 [tool.setuptools]
 packages = ["cohost", "cohost.models"]
+
+[tool.setuptools.package-data]
+"*" = ["py.typed"]


### PR DESCRIPTION
Hi again! This is a continuation to https://github.com/valknight/Cohost.py/pull/32 since, due to an oversight on my side, I forgot to explicitly tell `setuptools` to include the new `py.typed` file during build process. I realized version 0.3.3 didn't include the file although it did include all other changes, and a bit of looking around made me realize it wasn't being copied on purpose.

I checked these references:
- https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/ a blog post that coincidentally alerts people not to forget to do this :-P 
- https://github.com/DSD-DBS/pyease/blob/c5b42a2116460df53500c90ddd9df034054e5739/pyproject.toml#L177 to see how to include it on `pyproject.toml` without `poetry`

I verified that by running `python -m build` with this change, the compressed file that's generated contains the `py.typed` file but juuust in case, please double check if you can reproduce, and if not I'll keep looking around on how to fix this.

Thanks again and any suggestions welcome!