### PR TITLE
add support for listing asks

### DIFF
--- a/cohost/models/project.py
+++ b/cohost/models/project.py
@@ -116,6 +116,12 @@ class Project:
             "toProjectHandle": self.handle,
             "content": content,
             "anon": anon}, methodType='postjson')
+    
+    def getAsks(self):
+        rawResp = fetchTrpc('asks.listPending', self.user.cookie, {
+            'input': {'projectHandle': self.handle}
+        })
+        return rawResp['result']['data']['asks']
 
 
 class EditableProject(Project):

--- a/cohost/models/project.py
+++ b/cohost/models/project.py
@@ -116,8 +116,8 @@ class Project:
             "toProjectHandle": self.handle,
             "content": content,
             "anon": anon}, methodType='postjson')
-    
-    def getAsks(self):
+
+    def getAsksRaw(self) -> list[dict]:
         rawResp = fetchTrpc('asks.listPending', self.user.cookie, {
             'input': {'projectHandle': self.handle}
         })

--- a/cohost/network.py
+++ b/cohost/network.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import json
 import json.decoder
 import requests
 from typing import Any, Optional
@@ -92,6 +93,16 @@ def fetchTrpc(methods: list[str] | str, cookie: str,
         if cacheData is not None:
             logger.debug('Cache hit!')
             return cacheData
+    
+    # The trpc api expects values under "input" in a particular format, so we'll validate that here
+    if data and 'input' in data:
+        input_val = data.get('input')
+        if not isinstance(input_val, dict):
+            raise ValueError('For batch calls, there must be an "input" key with a dict value')
+        # We need to serialize the input object to JSON here
+        # Default requests behavior doesn't handle nested dicts the way we want
+        data['input'] = json.dumps(input_val)
+
     returnData = fetch(methodType, "/trpc/{}".format(m), data=data,
                        cookies=generate_login_cookies(cookie))
     assert isinstance(returnData, dict)

--- a/cohost/network.py
+++ b/cohost/network.py
@@ -98,7 +98,7 @@ def fetchTrpc(methods: list[str] | str, cookie: str,
     if data and 'input' in data:
         input_val = data.get('input')
         if not isinstance(input_val, dict):
-            raise ValueError('For batch calls, there must be an "input" key with a dict value')
+            raise ValueError('"input" key must have a dict value')
         # We need to serialize the input object to JSON here
         # Default requests behavior doesn't handle nested dicts the way we want
         data['input'] = json.dumps(input_val)


### PR DESCRIPTION
Pretty much what it sounds like. The asks endpoint is `asks.listPending` and it requires an `input` parameter, which should be a Python dict serialized to JSON. I tried to update `fetchTrpc` in a way that would work for other calls in the future