### PR TITLE
~ [Post.py] Fixed a small breaking typo in the key for transparentShareOfPostId

### DIFF
--- a/cohost/models/post.py
+++ b/cohost/models/post.py
@@ -42,7 +42,7 @@ class Post:
 
     @property
     def transparentShareOfPostId(self):
-        return self.postData['transparentShareofPostId']
+        return self.postData['transparentShareOfPostId']
 
     @property
     def state(self):


### PR DESCRIPTION
What it says on the tin, really.

Ran into this one while trying to figure out a workflow to archive shares as well for one of my prompt accounts, and figured I might as well fix it and contribute to the code that was helping me achieve my goals.