### PR TITLE
Adding share methods to Post and Project objects

### DIFF
--- a/cohost/models/post.py
+++ b/cohost/models/post.py
@@ -23,6 +23,22 @@ class Post:
             adult=adult,
             draft=draft
         )
+    
+    def share(self, headline: str, blocks: list = [], cws: list = [], 
+              tags: list = [], adult: bool = False, draft=False):
+        from cohost.models.project import EditableProject
+        if not isinstance(self.project, EditableProject):
+            raise AttributeError("Post isn't attached to an EditableProject -\
+                                 do you have Post permissions for this project?")
+        return self.project.post(
+            headline=headline,
+            blocks=blocks,
+            cws=cws,
+            tags=tags,
+            adult=adult,
+            draft=draft,
+            shareOfPostId=self.postId
+            )
 
     @property
     def postId(self):

--- a/cohost/models/project.py
+++ b/cohost/models/project.py
@@ -143,7 +143,7 @@ class EditableProject(Project):
         raise AttributeError("Project not found")
 
     def post(self, headline: str, blocks: list = [], cws: list = [],
-             tags: list = [], adult: bool = False, draft=False):
+             tags: list = [], adult: bool = False, draft=False, shareOfPostId: int = None):
         # Basic flow: you send a POST to project/{handle}/posts
         # This gives us back a post ID, as well as a API link
         # For example:
@@ -209,8 +209,12 @@ class EditableProject(Project):
             'adultContent': adult,
             'blocks': blockL,
             'cws': cws,
-            'tags': tags
+            'tags': tags,
         }
+        if shareOfPostId is not None:
+            postData.update({
+                    'shareOfPostId': shareOfPostId
+                })
         req = fetch(
             'postJSON',
             '/project/{}/posts'.format(self.handle),
@@ -237,6 +241,10 @@ class EditableProject(Project):
             'cws': cws,
             'tags': tags
         }
+        if shareOfPostId is not None:
+            postData.update({
+                    'shareOfPostId': shareOfPostId
+                })
         req = fetch(
             'put',
             '/project/{}/posts/{}'.format(self.handle, req['postId']),
@@ -272,6 +280,7 @@ class EditableProject(Project):
             'cws': cws,
             'tags': tags
         }
+
         req = fetch(
             'put',
             '/project/{}/posts/{}'.format(self.handle, postId),


### PR DESCRIPTION
Quick addition of share methods via post (only supports sharing a post from the same project that made the original post, with comment) and via project (by adding optional shareOfPostId field to Project.post)